### PR TITLE
create a new QSettings object

### DIFF
--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -48,9 +48,9 @@ static const int MAX_URI_LENGTH = 255;
 /* Number of frames in spinner animation */
 #define SPINNER_FRAMES 36
 
-#define QAPP_ORG_NAME "Bitcoin"
-#define QAPP_ORG_DOMAIN "bitcoin.org"
-#define QAPP_APP_NAME_DEFAULT "Bitcoin-Qt"
-#define QAPP_APP_NAME_TESTNET "Bitcoin-Qt-testnet"
+#define QAPP_ORG_NAME "BitcoinDiamond"
+#define QAPP_ORG_DOMAIN "btcd.io"
+#define QAPP_APP_NAME_DEFAULT "BitcoinDiamond-Qt"
+#define QAPP_APP_NAME_TESTNET "BitcoinDiamond-Qt-testnet"
 
 #endif // BITCOIN_QT_GUICONSTANTS_H


### PR DESCRIPTION
fix default data directory for qt is same as bitcoin in mac os
fix #11