### PR TITLE
NODE CONNECTIONS up to 20

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -59,9 +59,9 @@ static const unsigned int MAX_PROTOCOL_MESSAGE_LENGTH = 4 * 1000 * 1000;
 /** Maximum length of strSubVer in `version` message */
 static const unsigned int MAX_SUBVERSION_LENGTH = 256;
 /** Maximum number of automatic outgoing nodes */
-static const int MAX_OUTBOUND_CONNECTIONS = 8;
+static const int MAX_OUTBOUND_CONNECTIONS = 20;
 /** Maximum number of addnode outgoing nodes */
-static const int MAX_ADDNODE_CONNECTIONS = 8;
+static const int MAX_ADDNODE_CONNECTIONS = 20;
 /** -listen default */
 static const bool DEFAULT_LISTEN = true;
 /** -upnp default */


### PR DESCRIPTION
The default of 8 nodes is obviously not enough,so then ,Increase the number of default node connections
MAX_OUTBOUND_CONNECTIONS and MAX_ADDNODE_CONNECTIONS change to 20